### PR TITLE
Redstone Dust namespace

### DIFF
--- a/logicgates-fabric-1.18.2/src/main/resources/data/logicgates/recipes/wire_t.json
+++ b/logicgates-fabric-1.18.2/src/main/resources/data/logicgates/recipes/wire_t.json
@@ -9,7 +9,7 @@
     {
         "#": { "item": "minecraft:stone" },
         "R": { "item": "logicgates:wire" },
-        "T": { "item": "minecraft:redstone_dust" }
+        "T": { "tag": "c:dusts/redstone" }
     },
     "result":
     {


### PR DESCRIPTION
it is just minecraft:redstone in 1.18.2, not minecraft:redstone_dust, but tag  c:dusts/redstone is preferred can be compatible with other mods.