### PR TITLE
Revert "Redstone Dust namespace"

### DIFF
--- a/logicgates-fabric-1.18.2/src/main/resources/data/logicgates/recipes/wire_t.json
+++ b/logicgates-fabric-1.18.2/src/main/resources/data/logicgates/recipes/wire_t.json
@@ -9,7 +9,7 @@
     {
         "#": { "item": "minecraft:stone" },
         "R": { "item": "logicgates:wire" },
-        "T": { "tag": "c:dusts/redstone" }
+        "T": { "item": "minecraft:redstone_dust" }
     },
     "result":
     {


### PR DESCRIPTION
Reverts TheCSDev/mc-logic-gates#4
The following new recipe syntax doesn't even work:
```
"key":
    {
        "#": { "item": "minecraft:stone" },
        "R": { "item": "logicgates:wire" },
        "T": { "tag": "c:dusts/redstone" }
    },
```
Will use `"item":  "minecraft:redstone"` instead.